### PR TITLE
Work properly on root mounted engines

### DIFF
--- a/lib/omniauth/strategies/redbooth.rb
+++ b/lib/omniauth/strategies/redbooth.rb
@@ -43,6 +43,22 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get("#{options[:client_options][:site]}/me").parsed
       end
+
+      # Override OmniAuth's `request` method and make sure that
+      # `request.url` is properly defined when `PATH_INFO` doesn't
+      # start with a slash.
+      #
+      # This is needed because when mounting an engine on the root,
+      # the `path_prefix` cannot start with a slash. Because of that
+      # `request.url` becomes host:portpath (notice the lack of a slash).
+      #
+      # This code sets the `SCRIPT_NAME` environment variable to a slash
+      # if it's empty (meaning that it's the root) and then calls
+      # the parent code which instantiates a request.
+      def request
+        @env['SCRIPT_NAME'] = '/' if @env['SCRIPT_NAME'] == ''
+        super
+      end
     end
   end
 end


### PR DESCRIPTION
![giphy](https://cloud.githubusercontent.com/assets/56472/8162226/3e36649c-137c-11e5-9aa5-6be00c86b138.gif)
# What?

Properly generates the callback URL when working on a root mounted engine:
- Sets the `SCRIPT_NAME` environment variable to a slash when on root
- Changes the behavior of a `Rack::Request` generation
## Example
1. An engine is mounted at `/`
2. OmniAuth `path_prefix` is configured to `auth` (without leading slash)
3. `SCRIPT_NAME` will be set to a slash
4. `request.url` will now contain the host plus `/auth/:provider`
# Why?

When using OmniAuth inside a root mounted engine, the default `/auth/:provider` **must not** start with a slash, otherwise the middleware won't be able to match it with the requested path (rails removes trailing slashes from mounted engines paths). If the path doesn't start with a slash then `Rack::Request` will generate an invalid url, _e.g._, `http://localhost:3000auth/redbooth` (notice the missing slash).
# What to test?

Existing integrations using this gem shouldn't break.
