### PR TITLE
remove version restriction on omniauth-oauth2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Added
 ### Changed
+- remove version limit on omniauth-oath2 v1.3.1
+- added the documented workaround to cleanly support omniauth-oauth2 v1.4.0
+
 ### Deprecated
 ### Removed
 ### Deprecated

--- a/lib/omniauth/strategies/redbooth.rb
+++ b/lib/omniauth/strategies/redbooth.rb
@@ -27,6 +27,10 @@ module OmniAuth
         { 'raw_info' => raw_info }
       end
 
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       def raw_info
         @raw_info ||=
           access_token.get("#{options[:client_options][:site]}/me").parsed

--- a/omniauth-redbooth.gemspec
+++ b/omniauth-redbooth.gemspec
@@ -13,12 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = OmniAuth::Redbooth::VERSION
 
-  # Using 1.3.x branch since 1.4 added a non backward compatible change which
-  # prevents this gem from working.
-  #
-  # The issue is documented here:
-  # https://github.com/intridea/omniauth-oauth2/issues/81
-  gem.add_dependency 'omniauth-oauth2', '>= 1.0', '<= 1.3.1'
+  gem.add_dependency 'omniauth-oauth2', '>= 1.0'
 
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'rspec-its', '~> 1.2'


### PR DESCRIPTION
- this provides a clean workaround to handle version ~> 1.4
