### PR TITLE
Remove omniauth restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,15 @@
 ## [Unreleased]
 
 ### Added
+
+- Workaround on `#callback_url` for omniauth-oauth2 1.4.0
+
 ### Changed
 ### Deprecated
 ### Removed
+
+- Restriction on omniauth-oauth2 `< 1.4.0`
+
 ### Deprecated
 ### Fixed
 ### Security

--- a/lib/omniauth/strategies/redbooth.rb
+++ b/lib/omniauth/strategies/redbooth.rb
@@ -27,6 +27,17 @@ module OmniAuth
         { 'raw_info' => raw_info }
       end
 
+      # This is needed in order to support omniauth-oauth2 1.4.0, as for this
+      # version they made the gem more supportive of the OAuth2 standard,
+      # unfortunately not all OAuth2 providers support it.
+      #
+      # Theres more information about it here:
+      #
+      # https://github.com/intridea/omniauth-oauth2/issues/81
+      def callback_url
+        full_host + script_name + callback_path
+      end
+
       def raw_info
         @raw_info ||=
           access_token.get("#{options[:client_options][:site]}/me").parsed

--- a/omniauth-redbooth.gemspec
+++ b/omniauth-redbooth.gemspec
@@ -13,12 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = OmniAuth::Redbooth::VERSION
 
-  # Using 1.3.x branch since 1.4 added a non backward compatible change which
-  # prevents this gem from working.
-  #
-  # The issue is documented here:
-  # https://github.com/intridea/omniauth-oauth2/issues/81
-  gem.add_dependency 'omniauth-oauth2', '>= 1.0', '<= 1.3.1'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.0'
 
   gem.add_development_dependency 'rspec', '~> 3.0'
   gem.add_development_dependency 'rspec-its', '~> 1.2'


### PR DESCRIPTION
### :tophat:  What?

Remove the restriction on omniauth-oauth2 < 1.4

As from that version omniauth-oauth2 expects the Oauth2 provider to be compliant of the standard and fails otherwise. This introduces a workaround to avoid that issue.

https://github.com/intridea/omniauth-oauth2/issues/81 explains it.

Thanks @urkle for providing a solution here: https://github.com/teambox/omniauth-redbooth/pull/7